### PR TITLE
llamacppqwen36beellamavisionone: mount external chat template for opencode compact compatibility

### DIFF
--- a/llamacppqwen36beellamavisionone/files/qwen36_chat_template.jinja
+++ b/llamacppqwen36beellamavisionone/files/qwen36_chat_template.jinja
@@ -1,0 +1,192 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id is defined and add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id is defined and add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- set ns_flags = namespace(enable_thinking=true) %}
+{%- if enable_thinking is defined %}
+    {%- set ns_flags.enable_thinking = enable_thinking %}
+{%- endif %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n{"name": "example_function_name", "arguments": {"example_parameter_1": "value_1", "example_parameter_2": "This is the value for the second parameter"}}\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: a valid JSON object must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' or messages[0].role == 'developer' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if '<|think_off|>' in content %}
+            {%- set ns_flags.enable_thinking = false %}
+            {%- set content = content.replace('<|think_off|>', '').strip() %}
+        {%- elif '<|think_on|>' in content %}
+            {%- set ns_flags.enable_thinking = true %}
+            {%- set content = content.replace('<|think_on|>', '').strip() %}
+        {%- endif %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' or messages[0].role == 'developer' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if '<|think_off|>' in content %}
+            {%- set ns_flags.enable_thinking = false %}
+            {%- set content = content.replace('<|think_off|>', '').strip() %}
+        {%- elif '<|think_on|>' in content %}
+            {%- set ns_flags.enable_thinking = true %}
+            {%- set content = content.replace('<|think_on|>', '').strip() %}
+        {%- endif %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if '<|think_off|>' in content %}
+        {%- set ns_flags.enable_thinking = false %}
+        {%- set content = content.replace('<|think_off|>', '').strip() %}
+    {%- elif '<|think_on|>' in content %}
+        {%- set ns_flags.enable_thinking = true %}
+        {%- set content = content.replace('<|think_on|>', '').strip() %}
+    {%- endif %}
+    {%- if message.role == "system" or message.role == "developer" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+
+        {%- set has_explicit_tool_calls = message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+
+        {%- set clean_content = content %}
+        {%- if '<tool_call>' in content %}
+            {%- set clean_content = content.split('<tool_call>')[0].rstrip('\n') %}
+        {%- endif %}
+
+        {%- if loop.index0 > ns.last_query_index and reasoning_content %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + clean_content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + clean_content }}
+        {%- endif %}
+
+        {%- if has_explicit_tool_calls %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first and clean_content|trim %}
+                    {{- '\n\n<tool_call>\n' }}
+                {%- elif loop.first %}
+                    {{- '<tool_call>\n' }}
+                {%- else %}
+                    {{- '\n<tool_call>\n' }}
+                {%- endif %}
+                {{- '{"name": "' + tool_call.name + '", "arguments": ' }}
+                {%- if tool_call.arguments is defined and tool_call.arguments is mapping %}
+                    {{- tool_call.arguments | tojson }}
+                {%- elif tool_call.arguments is defined and tool_call.arguments is string %}
+                    {{- tool_call.arguments }}
+                {%- else %}
+                    {{- '{}' }}
+                {%- endif %}
+                {{- '}\n</tool_call>' }}
+            {%- endfor %}
+        {%- elif '<tool_call>' in content %}
+            {%- set raw_tool_blocks = content.split('<tool_call>')[1:] %}
+            {%- for raw_block in raw_tool_blocks %}
+                {%- set tool_block = raw_block.split('</tool_call>')[0] %}
+                {{- '\n\n<tool_call>' + tool_block + '</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if ns_flags.enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/llamacppqwen36beellamavisionone/templates/deployment.yaml
+++ b/llamacppqwen36beellamavisionone/templates/deployment.yaml
@@ -15,6 +15,15 @@ data:
   CTX_SIZE: "200000"
   THREADS: "16"
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: qwen36-chat-template
+  namespace: "{{ .Release.Namespace }}"
+data:
+  qwen36_chat_template.jinja: |
+{{ .Files.Get "files/qwen36_chat_template.jinja" | indent 4 }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -100,7 +109,9 @@ spec:
                 --cache-type-k turbo3 --cache-type-v turbo3 \
                 --batch-size 2048 --ubatch-size 2048 \
                 --parallel 1 --kv-unified \
-                --flash-attn on --jinja --no-mmap --mlock \
+                --flash-attn on --jinja \
+                --chat-template-file /chat-template/qwen36_chat_template.jinja \
+                --no-mmap --mlock \
                 --temp 0.6 --top-k 20 --min-p 0.0
           envFrom:
             - configMapRef:
@@ -148,15 +159,21 @@ spec:
               name: models
             - mountPath: "/shared-models"
               name: shared-models
+            - mountPath: "/chat-template"
+              name: chat-template
+              readOnly: true
       volumes:
-        - name: models
-          hostPath:
-            path: "{{ .Values.userspace.appData }}/models"
-            type: DirectoryOrCreate
-        - name: shared-models
-          hostPath:
-            path: "/olares/share/ai/model"
-            type: DirectoryOrCreate
+         - name: models
+           hostPath:
+             path: "{{ .Values.userspace.appData }}/models"
+             type: DirectoryOrCreate
+         - name: shared-models
+           hostPath:
+             path: "/olares/share/ai/model"
+             type: DirectoryOrCreate
+         - name: chat-template
+           configMap:
+             name: qwen36-chat-template
       restartPolicy: Always
 ---
 apiVersion: v1


### PR DESCRIPTION
The GGUF built-in chat template is incomplete, causing agentic failures when opencode triggers compaction. This replaces it with a proper Qwen3.6 Jinja chat template served as a ConfigMap.

**Chat template source:** https://raw.githubusercontent.com/abysslover/qwen36_tool_calling_failure/main/qwen35_chat_template.jinja

**Changes:**

- Add `files/qwen36_chat_template.jinja` with full tool-calling, thinking, vision, and multi-turn support
- Serve template via ConfigMap using `.Files.Get` to avoid Helm parsing Jinja2 as Go templates
- Add `--chat-template-file` to the llama.cpp server args
- Mount `/chat-template` volume (readOnly) from the ConfigMap
- Reformatted volumes block indentation for consistency

All existing BeeLlama.cpp args (speculative decoding, mmproj, turbo3 KV cache, --no-mmap, --mlock, etc.) are unchanged.